### PR TITLE
Better alignment for nested lists (fixes #25)

### DIFF
--- a/sass/screen.scss
+++ b/sass/screen.scss
@@ -119,6 +119,10 @@ article {
     ul, ol {
         list-style-position: outside;
         padding: 0;
+
+        li ul, li ol {
+            margin-left: 1.5em;
+        }
     }
     blockquote {
         margin: 0;


### PR DESCRIPTION
Currently, nested lists all align on the same left margin. Making them
nest properly was as simple as an alteration on their left-margin CSS
property. Hope that's sufficient.

Before: ![before](https://dl.dropbox.com/u/94814/Slingshot/Pictures/Screen%20Shot%202012-08-03%20at%2010.24.48%20AM.png)

After: ![after](https://dl.dropbox.com/u/94814/Slingshot/Pictures/Screen%20Shot%202012-08-03%20at%2010.25.04%20AM.png)

Signed-off-by: David Celis david@davidcelis.com
